### PR TITLE
Minor fixes related to connection string and info logging

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_flexible_server_util.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_flexible_server_util.py
@@ -13,7 +13,7 @@ from ._client_factory import resource_client_factory, network_client_factory
 
 logger = get_logger(__name__)
 
-DEFAULT_LOCATION = 'northeurope' #'eastus2euap'
+DEFAULT_LOCATION = 'eastus2euap' #'eastus2euap'
 
 
 def resolve_poller(result, cli_ctx, name):
@@ -74,13 +74,13 @@ def create_vnet(cmd, servername, location, resource_group_name, delegation_servi
     client = network_client_factory(cmd.cli_ctx)
     vnet_name, subnet_name, vnet_address_prefix, subnet_prefix = _create_vnet_metadata(servername)
 
-    logger.warning('Creating new vnet "%s" in resource group "%s"', vnet_name, resource_group_name)
+    logger.warning('Creating new vnet "%s" in resource group "%s"...', vnet_name, resource_group_name)
     client.virtual_networks.create_or_update(resource_group_name, vnet_name, VirtualNetwork(name=vnet_name, location=location, address_space=AddressSpace(
                                                                  address_prefixes=[vnet_address_prefix])))
     delegation = Delegation(name=delegation_service_name, service_name=delegation_service_name)
     subnet = Subnet(name=subnet_name, location=location, address_prefix=subnet_prefix, delegations=[delegation])
 
-    logger.warning('Creating new subnet "%s" in resource group "%s"', subnet_name, resource_group_name)
+    logger.warning('Creating new subnet "%s" in resource group "%s" and delegating it to "%s"...', subnet_name, resource_group_name, delegation_service_name)
     subnet = client.subnets.create_or_update(resource_group_name, vnet_name, subnet_name, subnet).result()
     return subnet.id
 
@@ -105,7 +105,7 @@ def create_firewall_rule(db_context, cmd, resource_group_name, server_name, star
         cmd.cli_ctx, '{} Firewall Rule Create/Update'.format(logging_name))
     '''
     firewall = firewall_client.create_or_update(resource_group_name, server_name, firewall_name, start_ip, end_ip).result()
-    return firewall.id
+    return firewall.name
 
 
 def parse_public_access_input(public_access):

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_help.py
@@ -831,3 +831,13 @@ examples:
   - name: Place the CLI in a waiting state until a creation of Active Directory Administrator in server testsvr.
     text: az postgres server ad-admin wait --server-name testsvr -g testgroup --created
 """
+
+helps['mysql flexible-server show-connection-string'] = """
+    type: command
+    short-summary: Show the connection strings for a MySQL flexible-server database.
+"""
+
+helps['postgres flexible-server show-connection-string'] = """
+    type: command
+    short-summary: Show the connection strings for a PostgreSQL flexible-server database.
+"""

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_mysql.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_mysql.py
@@ -48,19 +48,13 @@ def _flexible_server_create(cmd, client, resource_group_name=None, server_name=N
         logger.warning('Found existing MySQL Server \'%s\' in group \'%s\'',
                        server_name, resource_group_name)
 
-        # update server if needed
-        server_result = _update_server(
-            db_context, cmd, client, server_result, resource_group_name, server_name, backup_retention,
-            storage_mb, administrator_login_password)
-
     except CloudError:
         administrator_login_password = generate_password(administrator_login_password)
         if public_access is None:
-            print("**Commented out creating vnet until it is enabled**")
-            # subnet_id = create_vnet(cmd, server_name, location, resource_group_name, "Microsoft.MySQL/flexibleServers")
-            # delegated_subnet_arguments=mysql.flexibleservers.models.DelegatedSubnetArguments(
-            #     subnet_arm_resource_id=subnet_id
-            # )
+            subnet_id = create_vnet(cmd, server_name, location, resource_group_name, "Microsoft.MySQL/flexibleServers")
+            delegated_subnet_arguments=mysql.flexibleservers.models.DelegatedSubnetArguments(
+                subnet_arm_resource_id=subnet_id
+            )
 
         # Create mysql server
         # Note : passing public_access has no effect as the accepted values are 'Enabled' and 'Disabled'. So the value ends up being ignored.
@@ -335,37 +329,12 @@ def _create_server(db_context, cmd, resource_group_name, server_name, location, 
         '{} Server Create'.format(logging_name))
 
 
-def _update_server(db_context, cmd, client, server_result, resource_group_name, server_name, backup_retention,
-                   storage_mb, administrator_login_password):
-    # storage profile params
-    storage_profile_kwargs = {}
-    db_sdk, logging_name = db_context.azure_sdk, db_context.logging_name
-    if backup_retention is not None and backup_retention != server_result.storage_profile.backup_retention_days:
-        update_kwargs(storage_profile_kwargs, 'backup_retention_days', backup_retention)
-    if storage_mb != server_result.storage_profile.storage_mb:
-        update_kwargs(storage_profile_kwargs, 'storage_mb', storage_mb)
-
-    # update params
-    server_update_kwargs = {
-        'storage_profile': db_sdk.models.StorageProfile(**storage_profile_kwargs)
-    } if storage_profile_kwargs else {}
-    update_kwargs(server_update_kwargs, 'administrator_login_password', administrator_login_password)
-
-    if server_update_kwargs:
-        logger.warning('Updating existing %s Server \'%s\' with given arguments', logging_name, server_name)
-        params = db_sdk.models.ServerUpdateParameters(**server_update_kwargs)
-        return resolve_poller(client.update(
-            resource_group_name, server_name, params), cmd.cli_ctx, '{} Server Update'.format(logging_name))
-    return server_result
-
-
 def flexible_server_connection_string(
             server_name='{server}', database_name='{database}', administrator_login='{login}',
             administrator_login_password='{password}'):
-    user = '{}@{}'.format(administrator_login, server_name)
     host = '{}.mysql.database.azure.com'.format(server_name)
     return {
-        'connectionStrings': _create_mysql_connection_strings(host, user, administrator_login_password, database_name)
+        'connectionStrings': _create_mysql_connection_strings(host, administrator_login, administrator_login_password, database_name)
     }
 
 
@@ -384,7 +353,6 @@ def _create_mysql_connection_strings(host, user, password, database):
                   "port=3306, database='{database}')",
         'ruby': "client = Mysql2::Client.new(username: '{user}', password: '{password}', "
                 "database: '{database}', host: '{host}', port: 3306)",
-        'webapp': "Database={database}; Data Source={host}; User Id={user}; Password={password}"
     }
 
     connection_kwargs = {
@@ -408,13 +376,13 @@ def _form_response(username, sku, location, id, host, version, password, connect
         'location': location,
         'id': id,
         'version': version,
-        'database name': database_name,
-        'connection string': connection_string
+        'databaseName': database_name,
+        'connectionString': connection_string
     }
     if firewall_id is not None:
-        output['firewall id'] = firewall_id
+        output['firewallName'] = firewall_id
     if subnet_id is not None:
-        output['subnet id'] = subnet_id
+        output['subnetId'] = subnet_id
     return output
 
 

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -50,18 +50,13 @@ def _flexible_server_create(cmd, client,
         logger.warning('Found existing PostgreSQL Server \'%s\' in group \'%s\'',
                        server_name, resource_group_name)
 
-        # update server if needed
-        server_result = _update_server(
-            db_context, cmd, client, server_result, resource_group_name, server_name, backup_retention,
-            storage_mb, administrator_login_password)
     except CloudError:
         administrator_login_password = generate_password(administrator_login_password)
         if public_access is None:
-            print("**Commented out creating vnet until it is enabled**")
-            #subnet_id = create_vnet(cmd, server_name, location, resource_group_name, "Microsoft.DBforPostgreSQL/flexibleServers")
-            # delegated_subnet_arguments=postgresql.flexibleservers.models.ServerPropertiesDelegatedSubnetArguments(
-            #     subnet_arm_resource_id=subnet_id
-            # )
+            subnet_id = create_vnet(cmd, server_name, location, resource_group_name, "Microsoft.DBforPostgreSQL/flexibleServers")
+            delegated_subnet_arguments=postgresql.flexibleservers.models.ServerPropertiesDelegatedSubnetArguments(
+                 subnet_arm_resource_id=subnet_id
+            )
 
         # Create postgresql
         # Note : passing public_access has no effect as the accepted values are 'Enabled' and 'Disabled'. So the value ends up being ignored.
@@ -179,6 +174,7 @@ def _flexible_server_update_custom_func(instance,
             params.identity = instance.identity
     return params
 
+
 def _server_delete_func(cmd, client, resource_group_name=None, server_name=None, force=None):
     confirm = force
     if not force:
@@ -217,8 +213,10 @@ def _flexible_parameter_update(client, ids, server_name, configuration_name, res
 
     return client.update(resource_group_name, server_name, configuration_name, value, source)
 
+
 def _flexible_list_skus(client, location):
     return client.execute(location)
+
 
 def _create_server(db_context, cmd, resource_group_name, server_name, location, backup_retention, sku_name, tier,
                    storage_mb, administrator_login, administrator_login_password, version, tags, public_network_access,
@@ -258,37 +256,12 @@ def _create_server(db_context, cmd, resource_group_name, server_name, location, 
         '{} Server Create'.format(logging_name))
 
 
-def _update_server(db_context, cmd, client, server_result, resource_group_name, server_name, backup_retention,
-                   storage_mb, administrator_login_password):
-    # storage profile params
-    storage_profile_kwargs = {}
-    db_sdk, logging_name = db_context.azure_sdk, db_context.logging_name
-    if backup_retention is not None and backup_retention != server_result.storage_profile.backup_retention_days:
-        update_kwargs(storage_profile_kwargs, 'backup_retention_days', backup_retention)
-    if storage_mb != server_result.storage_profile.storage_mb:
-        update_kwargs(storage_profile_kwargs, 'storage_mb', storage_mb)
-
-    # update params
-    server_update_kwargs = {
-        'storage_profile': db_sdk.models.StorageProfile(**storage_profile_kwargs)
-    } if storage_profile_kwargs else {}
-    update_kwargs(server_update_kwargs, 'administrator_login_password', administrator_login_password)
-
-    if server_update_kwargs:
-        logger.warning('Updating existing %s Server \'%s\' with given arguments', logging_name, server_name)
-        params = db_sdk.models.ServerUpdateParameters(**server_update_kwargs)
-        return resolve_poller(client.update(
-            resource_group_name, server_name, params), cmd.cli_ctx, '{} Server Update'.format(logging_name))
-    return server_result
-
-
 def flexible_server_connection_string(
         server_name='{server}', database_name='{database}', administrator_login='{login}',
         administrator_login_password='{password}'):
-    user = '{}@{}'.format(administrator_login, server_name)
     host = '{}.postgres.database.azure.com'.format(server_name)
     return {
-        'connectionStrings': _create_postgresql_connection_strings(host, user, administrator_login_password, database_name)
+        'connectionStrings': _create_postgresql_connection_strings(host, administrator_login, administrator_login_password, database_name)
     }
 
 
@@ -306,7 +279,6 @@ def _create_postgresql_connection_strings(host, user, password, database):
                   "port='5432')",
         'ruby': "cnx = PG::Connection.new(:host => '{host}', :user => '{user}', :dbname => '{database}', "
                 ":port => '5432', :password => '{password}')",
-        'webapp': "Database={database}; Data Source={host}; User Id={user}; Password={password}"
     }
 
     connection_kwargs = {
@@ -338,12 +310,12 @@ def _form_response(username, sku, location, id, host, version, password, connect
         'location': location,
         'id': id,
         'version': version,
-        'connection string': connection_string
+        'connectionString': connection_string
     }
     if firewall_id is not None:
-        output['firewall id'] = firewall_id
+        output['firewallName'] = firewall_id
     if subnet_id is not None:
-        output['subnet id'] = subnet_id
+        output['subnetId'] = subnet_id
     return output
 
 

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -38,13 +38,13 @@ def _flexible_server_create(cmd, client,
     if subnet_arm_resource_id is not None:
         subnet_id = subnet_arm_resource_id # set the subnet id to be the one passed in
         delegated_subnet_arguments=postgresql.flexibleservers.models.ServerPropertiesDelegatedSubnetArguments(
-            subnet_arm_resource_id=subnet_arm_resource_id
+            subnet_arm_resource_id=subnet_id
         )
     else:
         delegated_subnet_arguments=None
 
+    location, resource_group_name, server_name = generate_missing_parameters(cmd, location, resource_group_name, server_name)
     try:
-        location, resource_group_name, server_name = generate_missing_parameters(cmd, location, resource_group_name, server_name)
         # The server name already exists in the resource group
         server_result = client.get(resource_group_name, server_name)
         logger.warning('Found existing PostgreSQL Server \'%s\' in group \'%s\'',
@@ -64,6 +64,7 @@ def _flexible_server_create(cmd, client,
             # )
 
         # Create postgresql
+        # Note : passing public_access has no effect as the accepted values are 'Enabled' and 'Disabled'. So the value ends up being ignored.
         server_result = _create_server(db_context, cmd, resource_group_name, server_name, location, backup_retention,
             sku_name, tier, storage_mb, administrator_login, administrator_login_password, version,
             tags, public_access, assign_identity, delegated_subnet_arguments, high_availability, zone)
@@ -230,6 +231,8 @@ def _create_server(db_context, cmd, resource_group_name, server_name, location, 
 
     from azure.mgmt.rdbms import postgresql
 
+    # Note : passing public-network-access has no effect as the accepted values are 'Enabled' and 'Disabled'.
+    # So when you pass an IP here(from the CLI args of public_access), it ends up being ignored.
     parameters = postgresql.flexibleservers.models.Server(
         sku=postgresql.flexibleservers.models.Sku(name=sku_name, tier=tier),
         administrator_login=administrator_login,


### PR DESCRIPTION
This PR contains the following :
Introduce informational message to indicate subnet delegation to service
Return Name of firewall added instead of firewall id
Add help for connection string commands
Remove code that handles update operation when user issues a create on an existing server
Uncomment VNET creation code
Remove @servername from username
Remove space from field names in creation output