### PR TITLE
Namespace updates (mysql_flexibleservers and postgresql_flexibleservers)

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_client_factory.py
@@ -72,7 +72,7 @@ def get_mysql_management_client(cli_ctx, **_):
 
 def get_mysql_flexible_management_client(cli_ctx, **_):
     from os import getenv
-    from azure.mgmt.rdbms.mysql.flexibleservers import MySQLManagementClient
+    from azure.mgmt.rdbms.mysql_flexibleservers import MySQLManagementClient
 
     # Allow overriding resource manager URI using environment variable
     # for testing purposes. Subscription id is also determined by environment
@@ -127,8 +127,7 @@ def get_postgresql_management_client(cli_ctx, **_):
 
 def get_postgresql_flexible_management_client(cli_ctx, **_):
     from os import getenv
-    from azure.mgmt.rdbms.postgresql.flexibleservers import PostgreSQLManagementClient
-
+    from azure.mgmt.rdbms.postgresql_flexibleservers import PostgreSQLManagementClient
     # Allow overriding resource manager URI using environment variable
     # for testing purposes. Subscription id is also determined by environment
     # variable.

--- a/src/azure-cli/azure/cli/command_modules/rdbms/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/custom.py
@@ -10,10 +10,8 @@ from msrestazure.tools import resource_id, is_valid_resource_id, parse_resource_
 from azure.cli.core.commands.client_factory import get_subscription_id
 from azure.cli.core.util import CLIError, sdk_no_wait
 from azure.mgmt.rdbms.mysql.operations._servers_operations import ServersOperations as MySqlServersOperations
-from azure.mgmt.rdbms.mysql.flexibleservers.operations._servers_operations import ServersOperations as MySqlFlexibleServersOperations
 from azure.mgmt.rdbms.mariadb.operations._servers_operations import ServersOperations as MariaDBServersOperations
-from ._client_factory import get_mariadb_management_client, get_mysql_management_client, get_postgresql_management_client, \
-    get_postgresql_flexible_management_client, get_mysql_flexible_management_client
+from ._client_factory import get_mariadb_management_client, get_mysql_management_client, get_postgresql_management_client
 
 SKU_TIER_MAP = {'Basic': 'b', 'GeneralPurpose': 'gp', 'MemoryOptimized': 'mo'}
 

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_commands.py
@@ -29,52 +29,52 @@ from ._transformers import table_transform_output, table_transform_output_list_s
 def load_flexibleserver_command_table(self, _):
     ## Flexible server SDKs:
     mysql_flexible_servers_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.rdbms.mysql.flexibleservers.operations#ServersOperations.{}',
+        operations_tmpl='azure.mgmt.rdbms.mysql_flexibleservers.operations#ServersOperations.{}',
         client_factory=cf_mysql_flexible_servers
     )
 
     mysql_flexible_firewall_rule_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.rdbms.mysql.flexibleservers.operations#FirewallRulesOperations.{}',
+        operations_tmpl='azure.mgmt.rdbms.mysql_flexibleservers.operations#FirewallRulesOperations.{}',
         client_factory=cf_mysql_flexible_firewall_rules
     )
 
     mysql_flexible_config_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.rdbms.mysql.flexibleservers.operations#ConfigurationsOperations.{}',
+        operations_tmpl='azure.mgmt.rdbms.mysql_flexibleservers.operations#ConfigurationsOperations.{}',
         client_factory=cf_mysql_flexible_config
     )
 
     mysql_flexible_db_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.rdbms.mysql.flexibleservers.operations#DatabasesOperations.{}',
+        operations_tmpl='azure.mgmt.rdbms.mysql_flexibleservers.operations#DatabasesOperations.{}',
         client_factory=cf_mysql_flexible_db
     )
 
     mysql_flexible_replica_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.rdbms.mysql.flexibleservers.operations#ReplicasOperations.{}',
+        operations_tmpl='azure.mgmt.rdbms.mysql_flexibleservers.operations#ReplicasOperations.{}',
         client_factory=cf_mysql_flexible_replica
     )
 
     mysql_flexible_location_capabilities_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.rdbms..mysql.flexibleservers.operations#LocationBasedCapabilitiesOperations.{}',
+        operations_tmpl='azure.mgmt.rdbms.mysql_flexibleservers.operations#LocationBasedCapabilitiesOperations.{}',
         client_factory=cf_mysql_flexible_location_capabilities
     )
 
     postgres_flexible_servers_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.rdbms.postgresql.flexibleservers.operations#ServersOperations.{}',
+        operations_tmpl='azure.mgmt.rdbms.postgresql_flexibleservers.operations#ServersOperations.{}',
         client_factory=cf_postgres_flexible_servers
     )
 
     postgres_flexible_firewall_rule_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.rdbms.postgresql.flexibleservers.operations#FirewallRulesOperations.{}',
+        operations_tmpl='azure.mgmt.rdbms.postgresql_flexibleservers.operations#FirewallRulesOperations.{}',
         client_factory=cf_postgres_flexible_firewall_rules
     )
 
     postgres_flexible_config_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.rdbms.postgresql.flexibleservers.operations#ConfigurationsOperations.{}',
+        operations_tmpl='azure.mgmt.rdbms.postgresql_flexibleservers.operations#ConfigurationsOperations.{}',
         client_factory=cf_postgres_flexible_config
     )
 
     postgres_flexible_location_capabilities_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.rdbms..postgresql.flexibleservers.operations#LocationBasedCapabilitiesOperations.{}',
+        operations_tmpl='azure.mgmt.rdbms..postgresql_flexibleservers.operations#LocationBasedCapabilitiesOperations.{}',
         client_factory=cf_postgres_flexible_location_capabilities
     )
 


### PR DESCRIPTION
- Updating the namespace from mysql.flexibleservers and postgresql.flexibleservers to mysql_flexibleservers and postgresql_flexibleservers per feedback.
- Minor fixes (fixing model name for resource identity and identity)
- Clean up unnecessary import statements


**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
